### PR TITLE
Add AVX2/SSE4 build options with auto-detection

### DIFF
--- a/keyhunt/Makefile
+++ b/keyhunt/Makefile
@@ -1,23 +1,39 @@
+SIMD ?= auto
+ifeq ($(SIMD),auto)
+SIMD_FLAG := $(shell if grep -q avx2 /proc/cpuinfo; then echo -mavx2; \
+	             elif grep -q sse4_1 /proc/cpuinfo; then echo -msse4.1; \
+	             else echo -mssse3; fi)
+else ifeq ($(SIMD),avx2)
+SIMD_FLAG := -mavx2
+else ifeq ($(SIMD),sse4)
+SIMD_FLAG := -msse4.1
+else
+SIMD_FLAG := -mssse3
+endif
+
+CXXFLAGS := -m64 -march=native -mtune=native $(SIMD_FLAG) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize
+CFLAGS   := -m64 -march=native -mtune=native $(SIMD_FLAG) -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize
+
 default:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	g++ $(CXXFLAGS) -flto -c oldbloom/bloom.cpp -o oldbloom.o
+	g++ $(CXXFLAGS) -flto -c bloom/bloom.cpp -o bloom.o
+	gcc $(CFLAGS) -c base58/base58.c -o base58.o
+	gcc $(CFLAGS) -c rmd160/rmd160.c -o rmd160.o
+	g++ $(CXXFLAGS) -c sha3/sha3.c -o sha3.o
+	g++ $(CXXFLAGS) -c sha3/keccak.c -o keccak.o
+	gcc $(CFLAGS) -c xxhash/xxhash.c -o xxhash.o
+	g++ $(CXXFLAGS) -c util.c -o util.o
+	g++ $(CXXFLAGS) -c secp256k1/Int.cpp -o Int.o
+	g++ $(CXXFLAGS) -c secp256k1/Point.cpp -o Point.o
+	g++ $(CXXFLAGS) -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+	g++ $(CXXFLAGS) -c secp256k1/IntMod.cpp -o IntMod.o
+	g++ $(CXXFLAGS) -flto -c secp256k1/Random.cpp -o Random.o
+	g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+	g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
+	g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
+	g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
+	g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
+	g++ $(CXXFLAGS) -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o Point.o SECP256K1.o IntMod.o Random.o IntGroup.o sha3.o keccak.o -lm -lpthread
 	rm -r *.o
 clean:
 	rm keyhunt
@@ -39,23 +55,23 @@ legacy:
 	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o GMP256K1.o  IntMod.o  IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp	
 	rm -r *.o
 bsgsd:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	g++ $(CXXFLAGS) -flto -c oldbloom/bloom.cpp -o oldbloom.o
+	g++ $(CXXFLAGS) -flto -c bloom/bloom.cpp -o bloom.o
+	gcc $(CFLAGS) -c base58/base58.c -o base58.o
+	gcc $(CFLAGS) -c rmd160/rmd160.c -o rmd160.o
+	g++ $(CXXFLAGS) -c sha3/sha3.c -o sha3.o
+	g++ $(CXXFLAGS) -c sha3/keccak.c -o keccak.o
+	gcc $(CFLAGS) -c xxhash/xxhash.c -o xxhash.o
+	g++ $(CXXFLAGS) -c util.c -o util.o
+	g++ $(CXXFLAGS) -c secp256k1/Int.cpp -o Int.o
+	g++ $(CXXFLAGS) -c secp256k1/Point.cpp -o Point.o
+	g++ $(CXXFLAGS) -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+	g++ $(CXXFLAGS) -c secp256k1/IntMod.cpp -o IntMod.o
+	g++ $(CXXFLAGS) -flto -c secp256k1/Random.cpp -o Random.o
+	g++ $(CXXFLAGS) -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+	g++ $(CXXFLAGS) -flto -c hash/ripemd160.cpp -o hash/ripemd160.o
+	g++ $(CXXFLAGS) -flto -c hash/sha256.cpp -o hash/sha256.o
+	g++ $(CXXFLAGS) -flto -c hash/ripemd160_sse.cpp -o hash/ripemd160_sse.o
+	g++ $(CXXFLAGS) -flto -c hash/sha256_sse.cpp -o hash/sha256_sse.o
+	g++ $(CXXFLAGS) -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o Point.o SECP256K1.o IntMod.o Random.o IntGroup.o sha3.o keccak.o -lm -lpthread
 	rm -r *.o

--- a/keyhunt/README.md
+++ b/keyhunt/README.md
@@ -97,7 +97,16 @@ First compile:
 make
 ```
 
-if you have problems compiling the `main` version you can compile the `legacy` version
+Keyhunt will try to detect your CPU SIMD capabilities (AVX2 or SSE4.1) and
+use the best instruction set available. You can override this detection by
+passing a `SIMD` parameter. For example to force AVX2 or SSE4 builds run:
+
+```
+make SIMD=avx2   # build with AVX2 instructions
+make SIMD=sse4   # build with SSE4.1 instructions
+```
+
+If you have problems compiling the `main` version you can compile the `legacy` version
 
 ```
 make legacy

--- a/keyhunt/secp256k1/Int.cpp
+++ b/keyhunt/secp256k1/Int.cpp
@@ -15,6 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <immintrin.h>
 #include "Int.h"
 #include "IntGroup.h"
 #include <cstdio>
@@ -79,8 +80,14 @@ void Int::CLEARFF() {
 // ------------------------------------------------
 
 void Int::Set(Int *a) {
+#if defined(__AVX2__)
+  __m256i v = _mm256_loadu_si256((__m256i*)a->bits64);
+  _mm256_storeu_si256((__m256i*)bits64, v);
+  bits64[4] = a->bits64[4];
+#else
   for (int i = 0; i<NB64BLOCK; i++)
-  	bits64[i] = a->bits64[i];
+        bits64[i] = a->bits64[i];
+#endif
 }
 
 // ------------------------------------------------


### PR DESCRIPTION
## Summary
- detect CPU SIMD capabilities in `Makefile` and build with AVX2 or SSE4.1 when available
- allow overriding detection via `SIMD` variable
- update `README` with instructions for AVX2/SSE4 builds
- use AVX2 in `Int::Set` when compiled with AVX2

## Testing
- `make SIMD=avx2`
- `make bsgsd SIMD=sse4`


------
https://chatgpt.com/codex/tasks/task_e_684f60a147e88322b6fd46a270a845ad