### PR TITLE
Add caching and large precomputation table

### DIFF
--- a/keyhunt/Makefile
+++ b/keyhunt/Makefile
@@ -1,23 +1,30 @@
+CPUFLAGS ?= -mssse3
+ifeq ($(AVX2),1)
+CPUFLAGS = -mavx2
+else ifeq ($(SSE41),1)
+CPUFLAGS = -msse4.1
+endif
+
 default:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o keyhunt keyhunt.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
 	rm -r *.o
 clean:
 	rm keyhunt
@@ -39,23 +46,23 @@ legacy:
 	g++ -march=native -mtune=native -Wall -Wextra -Ofast -ftree-vectorize -o keyhunt keyhunt_legacy.cpp base58.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o GMP256K1.o  IntMod.o  IntGroup.o Random.o hashing.o sha3.o keccak.o -lm -lpthread -lcrypto -lgmp	
 	rm -r *.o
 bsgsd:
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
-	gcc -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
-	g++ -m64 -march=native -mtune=native -mssse3 -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c oldbloom/bloom.cpp -o oldbloom.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c bloom/bloom.cpp -o bloom.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Ofast -ftree-vectorize -c base58/base58.c -o base58.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Ofast -ftree-vectorize -c rmd160/rmd160.c -o rmd160.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/sha3.c -o sha3.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c sha3/keccak.c -o keccak.o
+	gcc -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Ofast -ftree-vectorize -c xxhash/xxhash.c -o xxhash.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c util.c -o util.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Int.cpp -o Int.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/Point.cpp -o Point.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/SECP256K1.cpp -o SECP256K1.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -c secp256k1/IntMod.cpp -o IntMod.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/Random.cpp -o Random.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -flto -c secp256k1/IntGroup.cpp -o IntGroup.o
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160.o -ftree-vectorize -flto -c hash/ripemd160.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256.o -ftree-vectorize -flto -c hash/sha256.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/ripemd160_sse.o -ftree-vectorize -flto -c hash/ripemd160_sse.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -o hash/sha256_sse.o -ftree-vectorize -flto -c hash/sha256_sse.cpp
+	g++ -m64 -march=native -mtune=native $(CPUFLAGS) -Wall -Wextra -Wno-deprecated-copy -Ofast -ftree-vectorize -o bsgsd bsgsd.cpp base58.o rmd160.o hash/ripemd160.o hash/ripemd160_sse.o hash/sha256.o hash/sha256_sse.o bloom.o oldbloom.o xxhash.o util.o Int.o  Point.o SECP256K1.o  IntMod.o  Random.o IntGroup.o sha3.o keccak.o  -lm -lpthread
 	rm -r *.o

--- a/keyhunt/README.md
+++ b/keyhunt/README.md
@@ -97,6 +97,14 @@ First compile:
 make
 ```
 
+To build with AVX2 optimizations enable:
+
+```
+make AVX2=1
+```
+
+Use `SSE41=1` to force SSE4.1 on older CPUs.
+
 if you have problems compiling the `main` version you can compile the `legacy` version
 
 ```
@@ -1327,6 +1335,11 @@ Available in: https://github.com/WanderingPhilosopher/keyhunt
 Also thanks to @XopMC
 Available in: https://github.com/XopMC/keyhunt-win
 
+## Cache and giant table
+
+Use `-P <entries>` to enable an LRU cache for computed public keys. Larger values improve speed at the cost of memory.
+
+The option `-T <file>` activates a pre-computed 22-bit table (~5GB). On first run the table is generated and saved to the specified path.
 
 ## Thanks
 

--- a/keyhunt/cache.h
+++ b/keyhunt/cache.h
@@ -1,0 +1,55 @@
+#ifndef CACHE_H
+#define CACHE_H
+#include <unordered_map>
+#include <list>
+#include "secp256k1/Point.h"
+#include "secp256k1/Int.h"
+
+struct IntHash {
+    size_t operator()(Int const &a) const noexcept {
+        return (size_t)(a.bits64[0] ^ a.bits64[1]);
+    }
+};
+
+struct IntEq {
+    bool operator()(Int const &a, Int const &b) const noexcept {
+        return const_cast<Int&>(a).IsEqual(const_cast<Int*>(&b));
+    }
+};
+
+class LRUCache {
+public:
+    explicit LRUCache(size_t cap = 0) : capacity_(cap) {}
+    void setCapacity(size_t cap) { capacity_ = cap; clear(); }
+    size_t capacity() const { return capacity_; }
+    void clear() { map_.clear(); order_.clear(); }
+    bool get(const Int &k, Point &v) {
+        auto it = map_.find(k);
+        if(it==map_.end()) return false;
+        order_.splice(order_.begin(), order_, it->second.second);
+        v = it->second.first;
+        return true;
+    }
+    void put(const Int &k, const Point &v) {
+        if(capacity_==0) return;
+        auto it = map_.find(k);
+        if(it!=map_.end()) {
+            it->second.first = v;
+            order_.splice(order_.begin(), order_, it->second.second);
+            return;
+        }
+        if(map_.size() >= capacity_) {
+            const Int &old = order_.back();
+            map_.erase(old);
+            order_.pop_back();
+        }
+        order_.push_front(k);
+        map_.emplace(order_.front(), std::make_pair(v, order_.begin()));
+    }
+private:
+    size_t capacity_;
+    std::list<Int> order_;
+    std::unordered_map<Int, std::pair<Point,std::list<Int>::iterator>, IntHash, IntEq> map_;
+};
+
+#endif // CACHE_H

--- a/keyhunt/keyhunt.cpp
+++ b/keyhunt/keyhunt.cpp
@@ -23,6 +23,7 @@ email: albertobsd@gmail.com
 #include "secp256k1/Int.h"
 #include "secp256k1/IntGroup.h"
 #include "secp256k1/Random.h"
+#include "cache.h"
 
 #include "hash/sha256.h"
 #include "hash/ripemd160.h"
@@ -307,6 +308,10 @@ int FLAGRAWDATA	= 0;
 int FLAGRANDOM = 0;
 int FLAG_N = 0;
 int FLAGPRECALCUTED_P_FILE = 0;
+size_t PUBKEY_CACHE_SIZE = 0;
+LRUCache *pubkeyCache = NULL;
+char *TABLE22_PATH = NULL;
+int FLAG_TABLE22 = 0;
 
 int bitrange;
 char *str_N;
@@ -449,11 +454,32 @@ int main(int argc, char **argv)	{
 	int s;
 #endif
 
-	srand(time(NULL));
+        srand(time(NULL));
 
-	secp = new Secp256K1();
-	secp->Init();
-	OUTPUTSECONDS.SetInt32(30);
+        // Pre-scan for cache and table parameters
+        for(int pi=1; pi<argc; ++pi) {
+                if(strcmp(argv[pi],"-P")==0 && pi+1<argc) {
+                        PUBKEY_CACHE_SIZE = strtoull(argv[pi+1],NULL,10);
+                        ++pi;
+                } else if(strcmp(argv[pi],"-T")==0 && pi+1<argc) {
+                        FLAG_TABLE22 = 1;
+                        TABLE22_PATH = argv[pi+1];
+                        ++pi;
+                }
+        }
+
+        secp = new Secp256K1();
+        secp->useTable22 = FLAG_TABLE22;
+        secp->Init();
+        if(FLAG_TABLE22 && TABLE22_PATH) {
+                if(!secp->LoadTable22(TABLE22_PATH)) {
+                        printf("[I] Generating 22-bit table, please wait...\n");
+                        secp->SaveTable22(TABLE22_PATH);
+                }
+        }
+        if(PUBKEY_CACHE_SIZE>0)
+                pubkeyCache = new LRUCache(PUBKEY_CACHE_SIZE);
+        OUTPUTSECONDS.SetInt32(30);
 	ZERO.SetInt32(0);
 	ONE.SetInt32(1);
 	BSGS_GROUP_SIZE.SetInt32(CPU_GRP_SIZE);
@@ -486,7 +512,7 @@ int main(int argc, char **argv)	{
 	
 	printf("[+] Version %s, developed by AlbertoBSD\n",version);
 
-	while ((c = getopt(argc, argv, "deh6MqRSB:b:c:C:E:f:I:k:l:m:N:n:p:r:s:t:v:G:8:z:")) != -1) {
+        while ((c = getopt(argc, argv, "deh6MqRSB:b:c:C:E:f:I:k:l:m:N:n:p:r:s:t:v:G:8:z:P:T:")) != -1) {
 		switch(c) {
 			case 'h':
 				menu();
@@ -770,6 +796,15 @@ int main(int argc, char **argv)	{
 				}
 				printf("[+] Bloom Size Multiplier %i\n",FLAGBLOOMMULTIPLIER);
 			break;
+                        case 'P':
+                                PUBKEY_CACHE_SIZE = strtoull(optarg,NULL,10);
+                                printf("[+] Public key cache size %zu\n", PUBKEY_CACHE_SIZE);
+                        break;
+                        case 'T':
+                                FLAG_TABLE22 = 1;
+                                TABLE22_PATH = optarg;
+                                printf("[+] Using 22-bit table file %s\n", TABLE22_PATH);
+                        break;
 			default:
 				fprintf(stderr,"[E] Unknow opcion -%c\n",c);
 				exit(EXIT_FAILURE);

--- a/keyhunt/secp256k1/Int.cpp
+++ b/keyhunt/secp256k1/Int.cpp
@@ -292,6 +292,16 @@ unsigned char Int::GetByte(int n) {
 
 }
 
+uint32_t Int::GetBits(uint32_t startBit, uint32_t nBits) {
+  uint32_t word = startBit / 32;
+  uint32_t offset = startBit % 32;
+  uint64_t value = bits[word] >> offset;
+  if(offset + nBits > 32 && word + 1 < NB32BLOCK) {
+    value |= ((uint64_t)bits[word+1]) << (32 - offset);
+  }
+  return (uint32_t)(value & (((uint64_t)1 << nBits) - 1));
+}
+
 void Int::Set32Bytes(unsigned char *bytes) {
 
   CLEAR();

--- a/keyhunt/secp256k1/Int.h
+++ b/keyhunt/secp256k1/Int.h
@@ -156,6 +156,7 @@ public:
   uint32_t GetInt32();
   int GetBit(uint32_t n);
   unsigned char GetByte(int n);
+  uint32_t GetBits(uint32_t startBit, uint32_t nBits);
   void Get32Bytes(unsigned char *buff);
 
   char* GetBase2();

--- a/keyhunt/secp256k1/SECP256K1.cpp
+++ b/keyhunt/secp256k1/SECP256K1.cpp
@@ -20,10 +20,15 @@
 #include "SECP256k1.h"
 #include "Point.h"
 #include "../util.h"
+#include "../cache.h"
+
+extern LRUCache *pubkeyCache;
 #include "../hash/sha256.h"
 #include "../hash/ripemd160.h"
 
 Secp256K1::Secp256K1() {
+  useTable22 = false;
+  GTable22 = nullptr;
 }
 
 void Secp256K1::Init() {
@@ -53,38 +58,98 @@ void Secp256K1::Init() {
     GTable[i * 256 + 255] = N; // Dummy point for check function
   }
 
+  if(useTable22) {
+    size_t total = (size_t)WINDOW22_SIZE * WINDOW22_NUM;
+    GTable22 = new Point[total];
+    Point base(G);
+    // Precompute multiples for each window
+    for(int w=0; w<WINDOW22_NUM; ++w) {
+      size_t offset = (size_t)w * WINDOW22_SIZE;
+      GTable22[offset] = Point();
+      Point cur(base);
+      for(size_t i=1;i<WINDOW22_SIZE;i++) {
+        GTable22[offset+i] = cur;
+        cur = AddDirect(cur, base);
+      }
+      // Next window base is doubled WINDOW22_BITS times
+      for(int b=0;b<WINDOW22_BITS;b++) base = DoubleDirect(base);
+    }
+  }
+
 }
 
 Secp256K1::~Secp256K1() {
+  if(GTable22) {
+    delete[] GTable22;
+  }
 }
 
 Point Secp256K1::ComputePublicKey(Int *privKey) {
-  int i = 0;
-  uint8_t b;
-  Point Q;
-  Q.Clear();
-  // Search first significant byte
-  for (i = 0; i < 32; i++) {
-    b = privKey->GetByte(i);
-    if(b)
-      break;
+  Point cached;
+  if(pubkeyCache && pubkeyCache->get(*privKey, cached)) {
+    return cached;
   }
-  Q = GTable[256 * i + (b-1)];
-  i++;
+  if(useTable22 && GTable22) {
+    Point Q;
+    Q.Clear();
+    for(int w=0; w<WINDOW22_NUM; ++w) {
+      uint32_t bits = privKey->GetBits(w*WINDOW22_BITS, WINDOW22_BITS);
+      if(bits)
+        Q = Add2(Q, GTable22[(size_t)w*WINDOW22_SIZE + bits]);
+    }
+    Q.Reduce();
+    if(pubkeyCache) pubkeyCache->put(*privKey, Q);
+    return Q;
+  } else {
+    int i = 0;
+    uint8_t b;
+    Point Q;
+    Q.Clear();
+    // Search first significant byte
+    for (i = 0; i < 32; i++) {
+      b = privKey->GetByte(i);
+      if(b)
+        break;
+    }
+    Q = GTable[256 * i + (b-1)];
+    i++;
 
-  for(; i < 32; i++) {
-    b = privKey->GetByte(i);
-    if(b)
-      Q = Add2(Q, GTable[256 * i + (b-1)]);
+    for(; i < 32; i++) {
+      b = privKey->GetByte(i);
+      if(b)
+        Q = Add2(Q, GTable[256 * i + (b-1)]);
+    }
+    Q.Reduce();
+    if(pubkeyCache) pubkeyCache->put(*privKey, Q);
+    return Q;
   }
-  Q.Reduce();
-  return Q;
 }
 
 Point Secp256K1::NextKey(Point &key) {
   // Input key must be reduced and different from G
   // in order to use AddDirect
   return AddDirect(key,G);
+}
+
+bool Secp256K1::LoadTable22(const char *path) {
+  if(!path) return false;
+  FILE *f = fopen(path, "rb");
+  if(!f) return false;
+  size_t total = (size_t)WINDOW22_SIZE * WINDOW22_NUM;
+  if(!GTable22) GTable22 = new Point[total];
+  size_t r = fread(GTable22, sizeof(Point), total, f);
+  fclose(f);
+  return r == total;
+}
+
+bool Secp256K1::SaveTable22(const char *path) {
+  if(!path || !GTable22) return false;
+  FILE *f = fopen(path, "wb");
+  if(!f) return false;
+  size_t total = (size_t)WINDOW22_SIZE * WINDOW22_NUM;
+  size_t w = fwrite(GTable22, sizeof(Point), total, f);
+  fclose(f);
+  return w == total;
 }
 
 uint8_t Secp256K1::GetByte(char *str, int idx) {

--- a/keyhunt/secp256k1/SECP256k1.h
+++ b/keyhunt/secp256k1/SECP256k1.h
@@ -70,6 +70,15 @@ public:
   Int P;                   // Prime for the finite field
   Int   order;             // Curve order
 
+  // Huge 22-bit window table
+  bool useTable22;
+  Point *GTable22;
+  static const int WINDOW22_BITS = 22;
+  static const int WINDOW22_SIZE = 1 << WINDOW22_BITS;
+  static const int WINDOW22_NUM = 12;
+  bool LoadTable22(const char *path);
+  bool SaveTable22(const char *path);
+
 private:
 
   uint8_t GetByte(char *str,int idx);


### PR DESCRIPTION
## Summary
- add LRU cache implementation and hook into `ComputePublicKey`
- support optional 22‑bit precomputation table
- expose new CLI flags `-P` and `-T`
- add AVX2/SSE4 build flags
- document cache, table and build flags in README

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684f63f4af6083228ac7d1ed4ceaf61b